### PR TITLE
Separating parcellation code

### DIFF
--- a/batch_scripts/submit_transfer_file_job.sh
+++ b/batch_scripts/submit_transfer_file_job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#SBATCH --output=./logs/copy_data/output/job_output_%j.txt
-#SBATCH --error=./logs/copy_data/error/job_error_%j.txt
+#SBATCH --output=./logs/copy_data/output/job_output_%j.out
+#SBATCH --error=./logs/copy_data/error/job_error_%j.err
 #SBATCH --ntasks=1
 #SBATCH --time=24:00:00
 #SBATCH --mem=64G

--- a/tvb-ccmeg/compute_source.py
+++ b/tvb-ccmeg/compute_source.py
@@ -9,6 +9,8 @@
 # License: BSD (3-clause)
 
 import mne
+import os
+import numpy as np
 
 def setup_source_space(subject, subjects_dir):
     # Requires BEM surfaces to be computed in FreeSurfer directory

--- a/tvb-ccmeg/pipeline_rest_beamformer.py
+++ b/tvb-ccmeg/pipeline_rest_beamformer.py
@@ -42,7 +42,7 @@ meg_dir = os.path.join(data_dir, 'meg')  # Directory containing MEG data
 rest_raw_dname = os.path.join(meg_dir, 'release005/BIDSsep/derivatives_rest/aa/AA_nomovecomp/aamod_meg_maxfilt_00001')
 er_dname = os.path.join(meg_dir, 'release004/BIDS_20190411/meg_emptyroom')
 trans_dname = os.path.join(meg_dir, 'camcan_coreg/trans')
-raw_fname = os.path.join(meg_dir, subject, 'mf2pt2_' + subject + '_ses-rest_task-rest_meg.fif')
+raw_fname = os.path.join(rest_raw_dname, subject, 'mf2pt2_' + subject + '_ses-rest_task-rest_meg.fif')
 er_fname = os.path.join(er_dname, subject, 'emptyroom/emptyroom_' + subject[4:] + '.fif')
 trans = os.path.join(trans_dname, subject + '-trans.fif')
 # FreeSurfer outputs should be in a directory called 'freesurfer' with same parent directory as the pipeline code


### PR DESCRIPTION
Fix two path errors:
- rename file suffixes on log files for the file transfer code
- fix read in path error for MEG data

Pull parcellation code into a seperate function in compute_source.py
- add os and numpy to import list